### PR TITLE
build with primitive 0.8

### DIFF
--- a/tuples.cabal
+++ b/tuples.cabal
@@ -21,7 +21,7 @@ library
   exposed-modules: Data.Tuple.Types
   build-depends:
     , base >=4.11 && <5
-    , primitive >=0.6.4 && <0.8
+    , primitive >=0.6.4 && <0.9
   hs-source-dirs: src
   ghc-options: -Wall -O2
   default-language: Haskell2010


### PR DESCRIPTION
```
❯ cabal build --constraint="primitive == 0.8.0.0"
Resolving dependencies...
Build profile: -w ghc-9.4.4 -O1
In order, the following will be built (use -v for more details):
 - tuples-0.1.0.0 (lib) (first run)
Configuring library for tuples-0.1.0.0..
Preprocessing library for tuples-0.1.0.0..
Building library for tuples-0.1.0.0..
[1 of 1] Compiling Data.Tuple.Types ( src/Data/Tuple/Types.hs, /home/chessai/haskell/tuples/dist-newstyle/build/x86_64-linux/ghc-9.4.4/tuples-0.1.0.0/build/Data/Tuple/Types.o, /home/chessai/haskell/tuples/dist-newstyle/build/x86_64-linux/ghc-9.4.4/tuples-0.1.0.0/build/Data/Tuple/Types.dyn_o )
```